### PR TITLE
Redesign start page with Apple-inspired UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,328 +4,597 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Medical Learning Hub</title>
+    <link rel="preconnect" href="https://rsms.me/">
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
     <style>
         :root {
-            --primary-color: #007bff;
-            --secondary-color: #343a40;
-            --light-bg: #f8f9fa;
-            --white: #fff;
-            --gray: #e9ecef;
-            --shadow: rgba(0, 0, 0, 0.1);
+            --bg-0: #f5f5f7;
+            --bg-1: #ffffff;
+            --bg-2: #fbfbfd;
+            --ink-1: #1d1d1f;
+            --ink-2: #424245;
+            --ink-3: #6e6e73;
+            --ink-4: #a1a1a6;
+            --line: rgba(0, 0, 0, 0.08);
+            --line-strong: rgba(0, 0, 0, 0.14);
+            --accent: #0071e3;
+            --accent-hover: #0077ed;
+            --accent-soft: rgba(0, 113, 227, 0.08);
+            --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04), 0 2px 8px rgba(0, 0, 0, 0.04);
+            --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.06), 0 2px 6px rgba(0, 0, 0, 0.04);
+            --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.08), 0 4px 12px rgba(0, 0, 0, 0.04);
+            --radius-sm: 12px;
+            --radius-md: 18px;
+            --radius-lg: 24px;
+            --radius-xl: 28px;
+            --radius-pill: 999px;
+            --ease: cubic-bezier(0.22, 1, 0.36, 1);
         }
 
-        /* General Styles */
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg-0: #000000;
+                --bg-1: #1c1c1e;
+                --bg-2: #161618;
+                --ink-1: #f5f5f7;
+                --ink-2: #d2d2d7;
+                --ink-3: #98989d;
+                --ink-4: #6e6e73;
+                --line: rgba(255, 255, 255, 0.09);
+                --line-strong: rgba(255, 255, 255, 0.16);
+                --accent: #0a84ff;
+                --accent-hover: #409cff;
+                --accent-soft: rgba(10, 132, 255, 0.14);
+                --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.35);
+                --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.4);
+                --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.55);
+            }
+        }
+
+        * { box-sizing: border-box; }
+
+        html, body { height: 100%; }
+
         body {
-            font-family: 'Arial', sans-serif;
             margin: 0;
-            padding: 0;
-            background-color: var(--light-bg);
-            color: var(--secondary-color);
-            animation: fadeIn 1s ease-in-out;
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', Arial, sans-serif;
+            font-feature-settings: "cv11", "ss01", "ss03";
+            background: var(--bg-0);
+            color: var(--ink-1);
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+            letter-spacing: -0.01em;
+            line-height: 1.5;
+            overflow-x: hidden;
         }
 
-        a {
-            text-decoration: none;
+        body::before {
+            content: "";
+            position: fixed;
+            inset: -20% -20% auto -20%;
+            height: 70vh;
+            background:
+                radial-gradient(60% 60% at 20% 10%, rgba(0, 113, 227, 0.12), transparent 60%),
+                radial-gradient(50% 50% at 85% 15%, rgba(175, 82, 222, 0.10), transparent 60%),
+                radial-gradient(40% 40% at 50% 0%, rgba(48, 209, 88, 0.08), transparent 60%);
+            filter: blur(20px);
+            z-index: -1;
+            pointer-events: none;
         }
 
-        h1, h2, h3 {
-            margin: 0;
-        }
+        a { text-decoration: none; color: inherit; }
+        h1, h2, h3, h4, p { margin: 0; }
 
-        /* Animations */
-        @keyframes fadeIn {
-            from { opacity: 0; }
-            to { opacity: 1; }
-        }
-
-        @keyframes slideDown {
-            from { transform: translateY(-100%); opacity: 0; }
-            to { transform: translateY(0); opacity: 1; }
-        }
-
-        @keyframes slideUp {
-            from { transform: translateY(100%); opacity: 0; }
-            to { transform: translateY(0); opacity: 1; }
-        }
-
-        /* Header Styles */
+        /* Header — frosted floating bar */
         header {
-            background-color: var(--primary-color);
-            color: var(--white);
-            padding: 20px;
+            position: sticky;
+            top: 0;
+            z-index: 50;
+            backdrop-filter: saturate(180%) blur(20px);
+            -webkit-backdrop-filter: saturate(180%) blur(20px);
+            background: color-mix(in srgb, var(--bg-0) 72%, transparent);
+            border-bottom: 1px solid var(--line);
+        }
+
+        .header-inner {
+            max-width: 1240px;
+            margin: 0 auto;
+            padding: 14px 28px;
             display: flex;
-            justify-content: space-between;
             align-items: center;
-            animation: slideDown 0.8s ease-in-out;
+            justify-content: space-between;
+            gap: 24px;
+        }
+
+        .brand {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            font-weight: 600;
+            font-size: 15px;
+            letter-spacing: -0.015em;
+        }
+
+        .brand-mark {
+            width: 28px;
+            height: 28px;
+            border-radius: 8px;
+            background: linear-gradient(135deg, #0071e3, #af52de);
+            display: grid;
+            place-items: center;
+            color: #fff;
+            font-weight: 700;
+            font-size: 13px;
+            box-shadow: 0 2px 10px rgba(0, 113, 227, 0.35);
         }
 
         nav {
             display: flex;
+            align-items: center;
+            gap: 2px;
         }
 
         nav a {
-            color: var(--white);
-            padding: 10px 15px;
-            margin-right: 10px;
-            border-radius: 5px;
-            transition: transform 0.3s, background-color 0.3s;
+            color: var(--ink-2);
+            padding: 7px 12px;
+            font-size: 13px;
+            font-weight: 500;
+            border-radius: 8px;
+            transition: color 0.2s var(--ease), background-color 0.2s var(--ease);
         }
 
         nav a:hover {
-            background-color: rgba(255, 255, 255, 0.2);
-            transform: scale(1.1);
+            color: var(--ink-1);
+            background: var(--accent-soft);
         }
 
-        /* Main Section */
+        /* Hero */
         main {
-            padding: 20px;
-            max-width: 1200px; /* Limite la largeur pour les ordinateurs portables */
-            margin-left: auto; 
-            margin-right: auto; 
-            animation: fadeIn 1.2s ease-in-out; /* Animation d'entrée du contenu principal */
+            max-width: 1240px;
+            margin: 0 auto;
+            padding: 72px 28px 48px;
         }
 
-        main h2 {
+        .hero {
             text-align: center;
-            border-bottom: 2px solid var(--primary-color);
-            padding-bottom: 10px;
-            margin-bottom: 30px;
+            max-width: 780px;
+            margin: 0 auto 48px;
         }
 
-        .quote {
-          font-size: 1.2em; 
-          font-weight:bold; 
-          text-align:center; 
-          margin-bottom:20px; 
-          font-style: italic; /* Italique pour la citation */
-          color:#000080; /* Couleur accentuée pour la citation */
+        .eyebrow {
+            display: inline-block;
+            padding: 5px 12px;
+            font-size: 12px;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+            color: var(--accent);
+            background: var(--accent-soft);
+            border-radius: var(--radius-pill);
+            margin-bottom: 20px;
         }
 
-        .content-container {
+        .hero h1 {
+            font-size: clamp(40px, 5.2vw, 64px);
+            line-height: 1.05;
+            letter-spacing: -0.035em;
+            font-weight: 700;
+            background: linear-gradient(180deg, var(--ink-1) 0%, var(--ink-2) 100%);
+            -webkit-background-clip: text;
+            background-clip: text;
+            color: transparent;
+            margin-bottom: 18px;
+        }
+
+        .hero .quote {
+            font-size: clamp(15px, 1.3vw, 17px);
+            color: var(--ink-3);
+            font-weight: 400;
+            max-width: 640px;
+            margin: 0 auto;
+            line-height: 1.55;
+        }
+
+        /* Search — hero pill */
+        .search-wrap {
+            max-width: 680px;
+            margin: 36px auto 0;
+        }
+
+        form.search {
             display: flex;
-            flex-wrap: wrap;
-            gap: 20px; /* Espacement entre les sections */
+            align-items: center;
+            background: var(--bg-1);
+            border: 1px solid var(--line);
+            border-radius: var(--radius-pill);
+            padding: 6px 6px 6px 20px;
+            box-shadow: var(--shadow-md);
+            transition: border-color 0.25s var(--ease), box-shadow 0.25s var(--ease), transform 0.25s var(--ease);
         }
 
-        .goal-section, .important-links {
-            background-color: var(--white); /* Fond blanc pour les sections */
-            padding: 20px;
-            border-radius: 10px;
-            box-shadow: 0 4px 15px var(--shadow); /* Ombre portée */
-            transition: transform .3s ease-in-out; /* Transition pour effet de survol */
+        form.search:focus-within {
+            border-color: var(--accent);
+            box-shadow: 0 0 0 4px var(--accent-soft), var(--shadow-lg);
         }
 
-        .goal-section:hover, .important-links:hover {
-            transform: translateY(-5px); /* Effet de levée au survol */
+        .search-icon {
+            width: 18px;
+            height: 18px;
+            color: var(--ink-3);
+            flex-shrink: 0;
         }
 
-        .goal-section {
-            flex-basis: calc(70% - 20px); /* Ajustement de la largeur avec espacement */
+        form.search input[type="text"] {
+            flex: 1;
+            border: none;
+            outline: none;
+            background: transparent;
+            padding: 14px 14px;
+            font: inherit;
+            font-size: 16px;
+            color: var(--ink-1);
+            letter-spacing: -0.01em;
         }
 
-        .important-links {
-            flex-basis: calc(25% - 20px); /* Ajustement de la largeur avec espacement */
+        form.search input::placeholder { color: var(--ink-4); }
+
+        form.search button {
+            border: none;
+            background: var(--accent);
+            color: #fff;
+            font: inherit;
+            font-size: 14px;
+            font-weight: 600;
+            padding: 11px 22px;
+            border-radius: var(--radius-pill);
+            cursor: pointer;
+            transition: background-color 0.2s var(--ease), transform 0.2s var(--ease);
         }
 
-        .goal-section h3, .important-links h3 {
-            color: var(--primary-color); /* Couleur des titres */
-            margin-bottom: 15px;
+        form.search button:hover { background: var(--accent-hover); }
+        form.search button:active { transform: scale(0.97); }
+
+        /* Bento grid */
+        .bento {
+            display: grid;
+            grid-template-columns: 1.7fr 1fr;
+            gap: 20px;
+            margin-top: 56px;
         }
 
-        .goal-section ul {
-            list-style-type: none; /* Suppression des puces par défaut */
-            padding-left: 0; /* Suppression du remplissage par défaut */
+        @media (max-width: 960px) {
+            .bento { grid-template-columns: 1fr; }
         }
 
-        .goal-section ul li {
-           margin-bottom :15px; 
-       }
+        .card {
+            background: var(--bg-1);
+            border: 1px solid var(--line);
+            border-radius: var(--radius-lg);
+            padding: 32px;
+            box-shadow: var(--shadow-sm);
+            transition: transform 0.35s var(--ease), box-shadow 0.35s var(--ease), border-color 0.35s var(--ease);
+        }
 
-       .goal-section ul li strong { 
-           color:#343a40; 
-           font-weight:bold; 
-           font-size :1.1em; /* Taille de police augmentée pour mettre en avant */ 
-       } 
+        .card:hover {
+            transform: translateY(-2px);
+            box-shadow: var(--shadow-lg);
+            border-color: var(--line-strong);
+        }
 
-       .goal-section ul li em { 
-           display:block; 
-           color:#007bff; 
-           margin-top :5px; 
-           font-style :italic; 
-       } 
+        .card-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 22px;
+        }
 
-       .important-links a { 
-           display:flex; 
-           align-items:center; 
-           color:#007bff; 
-           margin-bottom :10px; 
-           transition :background-color .2s, transform .2s; /* Transition pour effet de survol */ 
-       } 
+        .card-title {
+            font-size: 22px;
+            font-weight: 600;
+            letter-spacing: -0.022em;
+            color: var(--ink-1);
+        }
 
-       .important-links a:hover { 
-           background-color :rgba(0,123,255,.1); 
-           transform :translateX(5px); /* Translation douce au survol */ 
-       } 
+        .card-kicker {
+            font-size: 12px;
+            font-weight: 500;
+            color: var(--ink-3);
+            letter-spacing: 0.02em;
+            text-transform: uppercase;
+        }
 
-       .important-links a img { 
-           width :24px; 
-           height :24px; 
-           margin-right :10px; 
-       } 
+        /* Daily program list */
+        .program {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            display: grid;
+            gap: 4px;
+        }
 
-       /* Search Box */
-       .search-box {
-           display:flex; 
-           align-items:center; 
-           justify-content:center; 
-           margin-bottom :30px; 
-           padding :10px ; /* Réduit le remplissage pour un look plus compact */
-           background-color:#fff; 
-           border-radius :30px; 
-           box-shadow :0 4px 15px var(--shadow); 
-       } 
+        .program li {
+            position: relative;
+            padding: 16px 0 16px 44px;
+            border-top: 1px solid var(--line);
+        }
 
-       form {
-           display:flex; 
-           width :100%;
-       }
+        .program li:first-child { border-top: none; padding-top: 4px; }
 
-       form input[type="text"] { 
-          flex-grow :1;  
-          padding :12px ;  
-          border:none ;  
-          border-radius :20px ;  
-          background-color:#f1f3f5 ;  
-          font-size :1em ;  
-          margin-right :10px ;  
-          box-shadow :inset 0 2px 4px rgba(0,0,0,.1);  
-          transition :background-color .3s ease, box-shadow .3s ease;} 
+        .program li::before {
+            counter-increment: step;
+            content: counter(step);
+            position: absolute;
+            left: 0;
+            top: 18px;
+            width: 28px;
+            height: 28px;
+            border-radius: 50%;
+            background: var(--accent-soft);
+            color: var(--accent);
+            font-size: 12px;
+            font-weight: 600;
+            display: grid;
+            place-items: center;
+        }
 
-       form input[type="text"]:focus {  
-          outline:none ;  
-          background-color:#e9ecef ;  
-          box-shadow :inset 0 4px 6px rgba(0,123,255,.3);  
-       } 
+        .program { counter-reset: step; }
 
-       form button {  
-          background-color:#007bff ;  
-          color:white ;  
-          border:none ;  
-          padding :10px ; /* Ajustement du remplissage pour un look plus compact */
-          border-radius :20px ;  
-          font-size :1em ;  
-          cursor:pointer ;  
-          transition :background-color .3s ease, box-shadow .3s ease;} 
+        .program li:first-child::before { top: 6px; }
 
-       form button:hover {  
-          background-color:#0056b3 ;  
-          box-shadow :0 4px 6px rgba(0,123,255,.4);  
-       } 
+        .program strong {
+            display: block;
+            font-size: 15px;
+            font-weight: 600;
+            color: var(--ink-1);
+            letter-spacing: -0.01em;
+            margin-bottom: 4px;
+        }
 
-       /* Footer */
-       footer {
-           text-align:center ;
-           padding :10px ; /* Réduction de la hauteur du pied de page */
-           background-color:#007bff ;
-           color:white ;
-           animation :slideUp .8s ease-in-out ;
-       }
-       
-       footer p {
-           font-size:.8em ; /* Réduction de la taille du texte dans le pied de page */
-       }
+        .program span {
+            display: block;
+            color: var(--ink-2);
+            font-size: 14px;
+            line-height: 1.55;
+        }
+
+        .program em {
+            display: block;
+            margin-top: 6px;
+            color: var(--ink-3);
+            font-style: normal;
+            font-size: 13px;
+        }
+
+        /* Important links */
+        .links {
+            display: grid;
+            gap: 4px;
+        }
+
+        .link-row {
+            display: flex;
+            align-items: center;
+            gap: 14px;
+            padding: 11px 12px;
+            border-radius: var(--radius-sm);
+            color: var(--ink-1);
+            font-size: 14px;
+            font-weight: 500;
+            transition: background-color 0.2s var(--ease), transform 0.2s var(--ease);
+        }
+
+        .link-row:hover {
+            background: var(--accent-soft);
+        }
+
+        .link-row .icon-tile {
+            width: 34px;
+            height: 34px;
+            border-radius: 9px;
+            background: var(--bg-2);
+            border: 1px solid var(--line);
+            display: grid;
+            place-items: center;
+            flex-shrink: 0;
+            overflow: hidden;
+        }
+
+        .link-row img {
+            width: 20px;
+            height: 20px;
+            object-fit: contain;
+        }
+
+        .link-row .chev {
+            margin-left: auto;
+            color: var(--ink-4);
+            opacity: 0;
+            transform: translateX(-4px);
+            transition: opacity 0.2s var(--ease), transform 0.2s var(--ease), color 0.2s var(--ease);
+        }
+
+        .link-row:hover .chev {
+            opacity: 1;
+            transform: translateX(0);
+            color: var(--accent);
+        }
+
+        /* Footer */
+        footer {
+            max-width: 1240px;
+            margin: 40px auto 0;
+            padding: 32px 28px 48px;
+            border-top: 1px solid var(--line);
+            text-align: center;
+        }
+
+        footer p {
+            color: var(--ink-3);
+            font-size: 13px;
+            line-height: 1.6;
+            max-width: 620px;
+            margin: 0 auto;
+        }
+
+        /* Entrance animations */
+        @keyframes rise {
+            from { opacity: 0; transform: translateY(12px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+
+        .hero, .search-wrap, .bento, footer {
+            animation: rise 0.7s var(--ease) both;
+        }
+
+        .search-wrap { animation-delay: 0.08s; }
+        .bento { animation-delay: 0.16s; }
+        footer { animation-delay: 0.24s; }
+
+        @media (max-width: 720px) {
+            main { padding: 48px 20px 24px; }
+            .header-inner { padding: 12px 20px; }
+            nav { display: none; }
+            .card { padding: 24px; }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            *, *::before, *::after {
+                animation: none !important;
+                transition: none !important;
+            }
+        }
     </style>
 </head>
 <body>
 <header>
-    <h1>Medical Learning Hub</h1>
-    <nav>
-      <a href="index.html">Home</a>
-      <a href="aio.html">AIO</a>
-      <a href="try-again.html">Try Again</a>
-      <a href="blueprint.html">Blueprint</a>
-	  <a href="search.html">Search</a>
-	  <a href="dynamic_search.html">Search+</a>
-      <a href="promo.html">Promo</a>
-      <a href="services.html">Services</a>
-    </nav>
+    <div class="header-inner">
+        <a href="index.html" class="brand">
+            <span class="brand-mark">M</span>
+            <span>Medical Learning Hub</span>
+        </a>
+        <nav>
+            <a href="index.html">Home</a>
+            <a href="aio.html">AIO</a>
+            <a href="try-again.html">Try Again</a>
+            <a href="blueprint.html">Blueprint</a>
+            <a href="search.html">Search</a>
+            <a href="dynamic_search.html">Search+</a>
+            <a href="promo.html">Promo</a>
+            <a href="services.html">Services</a>
+        </nav>
+    </div>
 </header>
 
 <main>
-    <h2>Your journey to medical excellence starts here</h2>
+    <section class="hero">
+        <span class="eyebrow">Your daily launchpad</span>
+        <h1>Your journey to medical excellence starts here.</h1>
+        <p class="quote">&ldquo;Adopt a positive mindset and put in the effort; Allah rewards hard work&mdash;embrace continuous learning and master your skills.&rdquo;</p>
 
-    <!-- Quote Section -->
-    <p class="quote">
-      "Adopt a positive mindset and put in the effort; Allah rewards hard work—embrace continuous learning and master your skills."
-    </p>
+        <div class="search-wrap">
+            <form class="search" action="https://www.perplexity.ai/search" method="GET" role="search">
+                <svg class="search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <circle cx="11" cy="11" r="7"></circle>
+                    <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                </svg>
+                <input type="text" name="q" placeholder="Search medical insights on Perplexity…" autocomplete="off">
+                <button type="submit">Search</button>
+            </form>
+        </div>
+    </section>
 
-    <!-- Search Box -->
-    <div class="search-box">
-      <img src="https://img.icons8.com/ios/50/000000/stethoscope.png" alt="Search Icon">
-      <form action="https://www.perplexity.ai/search" method="GET">
-         <input type="text" name="q" placeholder="Search medical insights...">
-         <button type="submit">Search</button>
-      </form>
-    </div>
+    <section class="bento">
+        <article class="card">
+            <div class="card-header">
+                <h2 class="card-title">Daily Program</h2>
+                <span class="card-kicker">Internalize &amp; master</span>
+            </div>
+            <ol class="program">
+                <li>
+                    <strong>Seize the day</strong>
+                    <span>11 PM bedtime. 5 AM rise — early to bed and early to rise makes a man healthy, wealthy, and wise.</span>
+                    <em>This routine fuels body, mind, and spirit.</em>
+                </li>
+                <li>
+                    <strong>Mental clarity &amp; focus</strong>
+                    <span>Set goals, keep a to-do list, visualize outcomes.</span>
+                    <em>Strengthen your focus, ignite your vision.</em>
+                </li>
+                <li>
+                    <strong>Deep work immersion</strong>
+                    <span>Dedicate <time datetime="PT4H">4 hours</time> of focused work. Eliminate distractions. Each task builds mastery.</span>
+                    <em>I am immersed in my work, growing every moment.</em>
+                </li>
+                <li>
+                    <strong>Power your body</strong>
+                    <span>Complete 50 push-ups and squats. Strength in the body mirrors strength in the mind.</span>
+                    <em>A healthy body leads to a bright mind.</em>
+                </li>
+                <li>
+                    <strong>Master your craft</strong>
+                    <span>Invest 15–30 minutes daily in skill learning or Anki review. Small, consistent steps.</span>
+                    <em>Each day, you compound your knowledge and skills.</em>
+                </li>
+            </ol>
+        </article>
 
-    <!-- Content Container -->
-    <div class="content-container">
-      <!-- Daily Program Section -->
-      <div class="goal-section">
-         <h3>Daily Program - Internalize and Master</h3>
-         <ul>
-             <li><strong>Seize the day:</strong> 11 PM: Bedtime. 5 AM: Early to bed and early to rise, makes a man healthy, wealthy, and wise<br><em>This powerful routine fuels your body, mind, and spirit.</em></li>
-             <li><strong>Mental Clarity and Focus:</strong> Set goals, have a To-do list, visualize. <br><em>Strengthen your focus, ignite your vision.</em></li>
-             <li><strong>Deep Work Immersion:</strong> Dedicate <time datetime="PT4H">4 hours</time> to focused work. Eliminate distractions. Each task builds mastery.<br><em>I am immersed in my work, growing every moment.</em></li>
-             <li><strong>Power your body</strong> Complete 50 push-ups and squats. Strength in the body mirrors strength in the mind.<br><em>A healthy body leads to a bright mind.</em></li>
-             <li><strong>Master your craft:</strong> Invest 15-30 minutes daily in skill learning or Anki review. Small consistent steps.<br><em>Each day, you're compounding your knowledge and skills.</em></li>
-         </ul>
-      </div>
-
-      <!-- Important Links Section -->
-      <div class="important-links">
-         <h3>Important Links</h3>
-         <a href="http://www.fmpm.uca.ma/?page_id=46" target="_blank" rel="noopener noreferrer">
-             <img src="https://raw.githubusercontent.com/achma-learning/achma-learning.github.io/refs/heads/main/images/fmpm.png" alt="FMPM Icon"> FMPM - Actualités
-         </a>
-         <a href="https://www.sante.gov.ma/Publications/Guides-Manuels/Pages/default.aspx" target="_blank" rel="noopener noreferrer">
-             <img src="https://iconape.com/wp-content/files/ov/257650/svg/257650.svg" alt="Guides et Manuels Icon"> Guide et Manuels - MSPS
-         </a>
-         <a href="https://thesefmpm.vercel.app/search" target="_blank" rel="noopener noreferrer">
-             <img src="https://cdn-icons-png.flaticon.com/512/2992/2992174.png" alt="These Icon"> These
-         </a>
-         <a href="https://drive.google.com/drive/folders/11VYUBnchs0OxHxUrK0l3Bw1v_0SgqX2J?usp=sharing" target="_blank" rel="noopener noreferrer">
-             <img src="https://cdn-icons-png.flaticon.com/512/5526/5526505.png" alt="Reference Icon"> Reference
-         </a>
-         <a href="https://amima-science.com/" target="_blank" rel="noopener noreferrer">
-             <img src="https://raw.githubusercontent.com/achma-learning/achma-learning.github.io/refs/heads/main/images/AMIMA.png" alt="AMIMA Icon"> AMIMA
-         </a>
-         <a href="https://recomedicales.fr/scores/" target="_blank" rel="noopener noreferrer">
-             <img src="https://recomedicales.fr/favicon.svg" alt="RecoMedicales Icon"> RecoMédicales
-         </a>
-         <a href="https://www.has-sante.fr/jcms/p_3076609/fr/edn" target="_blank" rel="noopener noreferrer">
-             <img src="https://www.has-sante.fr/plugins/ModuleHAS2019/images/logo-has-mobile.png" alt="FMPM Icon"> HAS - EDN
-         </a>
-          <a href="https://www.youtube.com/@lmellick/playlists" target="_blank" rel="noopener noreferrer">
-             <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7a/Circle-icons-video.svg/2048px-Circle-icons-video.svg.png" alt="yt Icon"> Larry B. Mellick, MD
-         </a>
-          <a href="https://www.mdcalc.com" target="_blank" rel="noopener noreferrer">
-             <img src="https://www.mdcalc.com/_next/static/media/MDCalcLogo.79fa2d9e.svg" alt="MDCalc Icon"> MDCalc
-         </a>
-          
-
-<!-- Icon credit to Flaticon.com -->
-          
-      </div>
-   </div>
-
+        <article class="card">
+            <div class="card-header">
+                <h2 class="card-title">Important Links</h2>
+                <span class="card-kicker">Curated</span>
+            </div>
+            <div class="links">
+                <a class="link-row" href="http://www.fmpm.uca.ma/?page_id=46" target="_blank" rel="noopener noreferrer">
+                    <span class="icon-tile"><img src="https://raw.githubusercontent.com/achma-learning/achma-learning.github.io/refs/heads/main/images/fmpm.png" alt=""></span>
+                    <span>FMPM — Actualités</span>
+                    <span class="chev">›</span>
+                </a>
+                <a class="link-row" href="https://www.sante.gov.ma/Publications/Guides-Manuels/Pages/default.aspx" target="_blank" rel="noopener noreferrer">
+                    <span class="icon-tile"><img src="https://iconape.com/wp-content/files/ov/257650/svg/257650.svg" alt=""></span>
+                    <span>Guides et Manuels — MSPS</span>
+                    <span class="chev">›</span>
+                </a>
+                <a class="link-row" href="https://thesefmpm.vercel.app/search" target="_blank" rel="noopener noreferrer">
+                    <span class="icon-tile"><img src="https://cdn-icons-png.flaticon.com/512/2992/2992174.png" alt=""></span>
+                    <span>Thèses</span>
+                    <span class="chev">›</span>
+                </a>
+                <a class="link-row" href="https://drive.google.com/drive/folders/11VYUBnchs0OxHxUrK0l3Bw1v_0SgqX2J?usp=sharing" target="_blank" rel="noopener noreferrer">
+                    <span class="icon-tile"><img src="https://cdn-icons-png.flaticon.com/512/5526/5526505.png" alt=""></span>
+                    <span>Reference</span>
+                    <span class="chev">›</span>
+                </a>
+                <a class="link-row" href="https://amima-science.com/" target="_blank" rel="noopener noreferrer">
+                    <span class="icon-tile"><img src="https://raw.githubusercontent.com/achma-learning/achma-learning.github.io/refs/heads/main/images/AMIMA.png" alt=""></span>
+                    <span>AMIMA</span>
+                    <span class="chev">›</span>
+                </a>
+                <a class="link-row" href="https://recomedicales.fr/scores/" target="_blank" rel="noopener noreferrer">
+                    <span class="icon-tile"><img src="https://recomedicales.fr/favicon.svg" alt=""></span>
+                    <span>RecoMédicales</span>
+                    <span class="chev">›</span>
+                </a>
+                <a class="link-row" href="https://www.has-sante.fr/jcms/p_3076609/fr/edn" target="_blank" rel="noopener noreferrer">
+                    <span class="icon-tile"><img src="https://www.has-sante.fr/plugins/ModuleHAS2019/images/logo-has-mobile.png" alt=""></span>
+                    <span>HAS — EDN</span>
+                    <span class="chev">›</span>
+                </a>
+                <a class="link-row" href="https://www.youtube.com/@lmellick/playlists" target="_blank" rel="noopener noreferrer">
+                    <span class="icon-tile"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7a/Circle-icons-video.svg/2048px-Circle-icons-video.svg.png" alt=""></span>
+                    <span>Larry B. Mellick, MD</span>
+                    <span class="chev">›</span>
+                </a>
+                <a class="link-row" href="https://www.mdcalc.com" target="_blank" rel="noopener noreferrer">
+                    <span class="icon-tile"><img src="https://www.mdcalc.com/_next/static/media/MDCalcLogo.79fa2d9e.svg" alt=""></span>
+                    <span>MDCalc</span>
+                    <span class="chev">›</span>
+                </a>
+            </div>
+        </article>
+    </section>
 </main>
 
 <footer>
-    <p style="margin-top: 10px; font-size: 0.8em;">
-      Do your efforts, God gives results, and God is the rich. Just keep up your efforts, and remember to stay humble.
-</p>
-
+    <p>Do your efforts, God gives results, and God is the rich. Just keep up your efforts, and remember to stay humble.</p>
 </footer>
 
 </body>


### PR DESCRIPTION
## Summary
Refreshes `index.html` with an Apple-inspired visual system while preserving every piece of content (nav, quote, daily program, all links, footer).

### What changed
- **Typography**: Inter with SF-style fallbacks, tighter letter-spacing, gradient display title.
- **Header**: Frosted sticky nav (backdrop-blur), gradient brand mark replacing the flat blue bar.
- **Hero**: Eyebrow tag, centered display heading, refined quote treatment, ambient radial gradient backdrop.
- **Search**: Pill-shaped hero search with SVG icon, focus ring, and soft elevation.
- **Layout**: Flex grid replaced with a 1.7:1 bento grid of two elevated cards.
- **Daily Program**: Numbered step-list with accent bullets; clearer hierarchy between title, detail, and affirmation.
- **Important Links**: Icon-tile rows with chevron reveal on hover; all original URLs intact.
- **Footer**: Quiet, bordered, centered — gets out of the way.
- **System features**: `prefers-color-scheme: dark` palette, `prefers-reduced-motion` honored, responsive down to mobile.

## Test plan
- [ ] Open `index.html` on a laptop (1440px) and desktop (1920px) — verify bento grid and hero scale cleanly.
- [ ] Hover cards and link rows — confirm lift, chevron reveal, and focus ring on search.
- [ ] Toggle system dark mode — confirm palette switches.
- [ ] Submit the search — confirm it still posts to Perplexity.
- [ ] Click each nav link and important link — confirm URLs unchanged.
